### PR TITLE
Start adding HTML samples, and serving them via GH Pages

### DIFF
--- a/samples/index.html
+++ b/samples/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+
+<html lang="en-GB">
+
+  <head>
+    <meta charset="utf-8">
+    <title>Mail archive samples</title>
+  </head>
+
+  <body>
+
+    <header>
+      <h1>Mail archive samples</h1>
+    </header>
+
+    <main>
+      <ul>
+        <li><a href="public-index.html">Public ML index</a> (<code>https://lists.w3.org/Archives/Public/public-html-mail/2007May/</code>)</li>
+        <li><a href="public-messsage.html">Public ML message</a> (<code>https://lists.w3.org/Archives/Public/public-html-mail/2007May/0002.html</code>)</li>
+        <li><a href="member-index.html">Member-only ML index</a></li>
+        <li><a href="member-messsage.html">Member-only ML message</a></li>
+        <li><a href="team-index.html">Team-only ML index</a></li>
+        <li><a href="team-messsage.html">Team-only ML message</a></li>
+      </ul>
+    </main>
+
+    <footer>
+      <p>Project: <a href="https://github.com/w3c/mailing-list-archives"><code>github.com/w3c/mailing-list-archives</code></a></p>
+    </footer>
+
+  </body>
+
+</html>

--- a/samples/index.html
+++ b/samples/index.html
@@ -15,12 +15,14 @@
 
     <main>
       <ul>
-        <li><a href="public-index.html">Public ML index</a> (<code>https://lists.w3.org/Archives/Public/public-html-mail/2007May/</code>)</li>
-        <li><a href="public-messsage.html">Public ML message</a> (<code>https://lists.w3.org/Archives/Public/public-html-mail/2007May/0002.html</code>)</li>
-        <li><a href="member-index.html">Member-only ML index</a></li>
-        <li><a href="member-messsage.html">Member-only ML message</a></li>
+        <li><a href="public-index.html">Public ML index</a>
+	  (compare with <a href="https://lists.w3.org/Archives/Public/public-html-mail/2007May/">the current version</a>)</li>
+        <li><a href="public-message.html">Public ML message</a>
+	  (compare with <a href="https://lists.w3.org/Archives/Public/public-html-mail/2007May/0002.html">the current version</a>)</li>
+        <!-- li><a href="member-index.html">Member-only ML index</a></li>
+        <li><a href="member-message.html">Member-only ML message</a></li>
         <li><a href="team-index.html">Team-only ML index</a></li>
-        <li><a href="team-messsage.html">Team-only ML message</a></li>
+        <li><a href="team-message.html">Team-only ML message</a></li -->
       </ul>
     </main>
 

--- a/samples/public-index.html
+++ b/samples/public-index.html
@@ -8,7 +8,7 @@
 <title>public-html-mail@w3.org from May 2007: by date</title>
 <meta name="Subject" content="by date" />
 <meta name="robots" content="noindex" />
-<link rel="stylesheet" href="../style/public-messagelist" type="text/css" />
+<link rel="stylesheet" href="../style/public-messagelist.css" type="text/css" />
 <link rel="alternate stylesheet" title="Shorter view" 
     href="../style/style-short.css" />
 <link rel="help" href="/Help/" />

--- a/samples/public-index.html
+++ b/samples/public-index.html
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<meta name="generator" content="hypermail 2.3.1, see http://www.hypermail-project.org/" />
+<title>public-html-mail@w3.org from May 2007: by date</title>
+<meta name="Subject" content="by date" />
+<meta name="robots" content="noindex" />
+<link rel="stylesheet" href="//www.w3.org/StyleSheets/Mail/public-messagelist" type="text/css" />
+<link rel="alternate stylesheet" title="Shorter view" 
+    href="//www.w3.org/StyleSheets/Mail/style-short.css" />
+<link rel="help" href="/Help/" />
+<link rel="start" href="../" title= "public-html-mail@w3.org archives" />
+</head>
+<body>
+<div class="head">
+<map title="Navigation bar to upper levels" id="upper">
+<p>
+   <a href="//www.w3.org/" title="W3C home">W3C home</a> &gt;
+   <a href="/" title="Mailing lists archives">Mailing
+    lists</a> &gt;
+   <a href="../../" title="Public mailing
+lists">Public</a> &gt;
+   <a href="../" title="Index of public-html-mail@w3.org" rel="start">public-html-mail@w3.org</a> &gt;
+   <a href="./" rel="contents" title="Messages received in May 2007">May 2007</a>
+</p>
+</map>
+<h1>public-html-mail@w3.org from May 2007 by date</h1>
+<map title="Navigation bar" id="navbar" name="navbar">
+<ul>
+<li><dfn><a href="#first" title="jump to messages list" tabindex="1">39 messages</a></dfn>: <dfn>Starting</dfn> Wednesday,  2 May 2007 03:18:28 UTC, <dfn>Ending</dfn> Tuesday, 29 May 2007 06:04:58 UTC</li>
+<li><dfn>sort by</dfn>: [ <a href="thread.html" title="Contemporary discussion threads" accesskey="t" rel="alternate">thread</a> ]
+ [ <a href="author.html" title="Contemporary messages by author" accesskey="a" rel="alternate">author</a> ]
+ [ date ]
+ [ <a href="subject.html" title="Contemporary messages by subject" accesskey="s" rel="alternate">subject</a> ]
+</li>
+<li><dfn>Mail actions</dfn>: [ <a href="mailto:public-html-mail&#x40;&#0119;&#0051;&#0046;&#0111;&#0114;&#0103;" accesskey="n">mail a new topic</a> ]</li>
+<li><dfn>Help</dfn>: [ <a href=
+   "/Help/" accesskey="h" rel="help">How to use the archives</a> ] [ <a href=
+   "https://www.w3.org/Search/Mail/Public/search?type-index=public-html-mail&amp;index-type=t">Search in the archives</a> ]
+</li></ul>
+</map>
+</div>
+<div class="messages-list">
+<ul>
+<li><a  accesskey="j" name="first" id="first"></a><dfn>Tuesday, 29 May 2007</dfn><ul>
+<li><a href="0038.html">Minutes of HTML in Email Workshop</a>&nbsp;<a name="msg38" id="msg38"><em>Karl Dubost</em></a>&nbsp;</li>
+</ul></li>
+<li><dfn>Thursday, 24 May 2007</dfn><ul>
+<li><a href="0037.html">Re: HTML Email Workshop in Paris</a>&nbsp;<a name="msg37" id="msg37"><em>Daniel Glazman</em></a>&nbsp;</li>
+</ul></li>
+<li><dfn>Wednesday, 23 May 2007</dfn><ul>
+<li><a href="0036.html">Re: Presentations vs. papers</a>&nbsp;<a name="msg36" id="msg36"><em>Stephane Deschamps</em></a>&nbsp;</li>
+<li><a href="0035.html">Re: Presentations vs. papers</a>&nbsp;<a name="msg35" id="msg35"><em>Dave Crocker</em></a>&nbsp;</li>
+<li><a href="0034.html">Re: Presentations vs. papers</a>&nbsp;<a name="msg34" id="msg34"><em>Stephane Deschamps</em></a>&nbsp;</li>
+<li><a href="0033.html">HTML Email Workshop in Paris</a>&nbsp;<a name="msg33" id="msg33"><em>James Richards</em></a>&nbsp;</li>
+<li><a href="0032.html">Re: Presentations vs. papers</a>&nbsp;<a name="msg32" id="msg32"><em>Daniel Glazman</em></a>&nbsp;</li>
+<li><a href="0031.html">Presentations vs. papers</a>&nbsp;<a name="msg31" id="msg31"><em>DESCHAMPS Stephane ROSI/SI CLIENT</em></a>&nbsp;</li>
+<li><a href="0030.html">Re: HTML Email Workshop in Paris</a>&nbsp;<a name="msg30" id="msg30"><em>Karl Dubost</em></a>&nbsp;</li>
+<li><a href="0029.html">HTML Email Workshop in Paris</a>&nbsp;<a name="msg29" id="msg29"><em>Julie Landry</em></a>&nbsp;</li>
+<li><a href="0028.html">Re: HTML in email Workshop, wednesday evening</a>&nbsp;<a name="msg28" id="msg28"><em>Daniel Glazman</em></a>&nbsp;</li>
+</ul></li>
+<li><dfn>Tuesday, 22 May 2007</dfn><ul>
+<li><a href="0027.html">Re: W3C HTML Email Workshop -- Internet Mail Architecture</a>&nbsp;<a name="msg27" id="msg27"><em>Dave Crocker</em></a>&nbsp;</li>
+<li><a href="0026.html">[workshop] Agenda, list of Participants, Logistics</a>&nbsp;<a name="msg26" id="msg26"><em>Karl Dubost</em></a>&nbsp;</li>
+<li><a href="0025.html">Re: HTML Email Workshop in Paris</a>&nbsp;<a name="msg25" id="msg25"><em>Karl Dubost</em></a>&nbsp;</li>
+<li><a href="0024.html">Re: HTML in email Workshop, draft agenda</a>&nbsp;<a name="msg24" id="msg24"><em>Karl Dubost</em></a>&nbsp;</li>
+<li><a href="0023.html">HTML in email Workshop, wednesday evening</a>&nbsp;<a name="msg23" id="msg23"><em>Adrien Leygues</em></a>&nbsp;</li>
+<li><a href="0022.html">Re: W3C HTML Email Workshop -- Internet Mail Architecture</a>&nbsp;<a name="msg22" id="msg22"><em>Daniel Glazman</em></a>&nbsp;</li>
+<li><a href="0021.html">Re: W3C HTML Email Workshop -- Internet Mail Architecture</a>&nbsp;<a name="msg21" id="msg21"><em>Dave Crocker</em></a>&nbsp;</li>
+<li><a href="0020.html">Re: HTML in email Workshop, wednesday evening</a>&nbsp;<a name="msg20" id="msg20"><em>Chris Lilley</em></a>&nbsp;</li>
+</ul></li>
+<li><dfn>Monday, 21 May 2007</dfn><ul>
+<li><a href="0019.html">HTML in email Workshop, draft agenda</a>&nbsp;<a name="msg19" id="msg19"><em>Daniel Glazman</em></a>&nbsp;</li>
+<li><a href="0018.html">HTML in email Workshop, wednesday evening</a>&nbsp;<a name="msg18" id="msg18"><em>Daniel Glazman</em></a>&nbsp;</li>
+<li><a href="0017.html">W3C HTML Email Workshop -- Newsletter</a>&nbsp;<a name="msg17" id="msg17"><em>Paul Ney</em></a>&nbsp;</li>
+</ul></li>
+<li><dfn>Thursday, 17 May 2007</dfn><ul>
+<li><a href="0016.html">Re: HTML Email Workshop in Paris</a>&nbsp;<a name="msg16" id="msg16"><em>Karl Dubost</em></a>&nbsp;</li>
+</ul></li>
+<li><dfn>Wednesday, 16 May 2007</dfn><ul>
+<li><a href="0015.html">HTML Email Workshop in Paris</a>&nbsp;<a name="msg15" id="msg15"><em>Adrien Leygues</em></a>&nbsp;</li>
+</ul></li>
+<li><dfn>Tuesday, 15 May 2007</dfn><ul>
+<li><a href="0014.html">HTML Email Workshop in Paris</a>&nbsp;<a name="msg14" id="msg14"><em>Ian Deshays</em></a>&nbsp;</li>
+<li><a href="0013.html">HTML mail Workshop in 1 week</a>&nbsp;<a name="msg13" id="msg13"><em>Karl Dubost</em></a>&nbsp;</li>
+<li><a href="0012.html">Participating in the W3 Workshop</a>&nbsp;<a name="msg12" id="msg12"><em>Brendan McNamara</em></a>&nbsp;</li>
+</ul></li>
+<li><dfn>Monday, 14 May 2007</dfn><ul>
+<li><a href="0011.html">HTML Email Workshop in Paris</a>&nbsp;<a name="msg11" id="msg11"><em>PATONNIER Jeremie \(Cetelem\)</em></a>&nbsp;</li>
+<li><a href="0010.html">Re: HTML Email Workshop - Position Paper</a>&nbsp;<a name="msg10" id="msg10"><em>Daniel Glazman</em></a>&nbsp;</li>
+<li><a href="0009.html">RE: HTML Email Workshop - Position Paper</a>&nbsp;<a name="msg9" id="msg9"><em>Rawlings, Darren</em></a>&nbsp;</li>
+</ul></li>
+<li><dfn>Thursday, 10 May 2007</dfn><ul>
+<li><a href="0008.html">HTML Email Workshop in Paris</a>&nbsp;<a name="msg8" id="msg8"><em>Brendan McNamara</em></a>&nbsp;</li>
+<li><a href="0007.html">RE: HTML Email Workshop in Paris</a>&nbsp;<a name="msg7" id="msg7"><em>Nicolas Naparty</em></a>&nbsp;</li>
+</ul></li>
+<li><dfn>Wednesday,  9 May 2007</dfn><ul>
+<li><a href="0006.html">HTML in mail Workshop in *two* weeks</a>&nbsp;<a name="msg6" id="msg6"><em>Karl Dubost</em></a>&nbsp;</li>
+<li><a href="0005.html">Re: Position Papers Guidelines for W3C Workshop</a>&nbsp;<a name="msg5" id="msg5"><em>Karl Dubost</em></a>&nbsp;</li>
+</ul></li>
+<li><dfn>Tuesday,  8 May 2007</dfn><ul>
+<li><a href="0004.html">Re: HTML in email Workshop</a>&nbsp;<a name="msg4" id="msg4"><em>Karl Dubost</em></a>&nbsp;</li>
+</ul></li>
+<li><dfn>Thursday,  3 May 2007</dfn><ul>
+<li><a href="0003.html">RE: Position Paper on Accessibility</a>&nbsp;<a name="msg3" id="msg3"><em>DESCHAMPS Stephane ROSI/SI CLIENT</em></a>&nbsp;</li>
+</ul></li>
+<li><dfn>Wednesday,  2 May 2007</dfn><ul>
+<li><a href="0002.html">Email security position paper</a>&nbsp;<a name="msg2" id="msg2"><em>Chris Newman</em></a>&nbsp;</li>
+<li><a href="0001.html">HTML in email Workshop</a>&nbsp;<a name="msg1" id="msg1"><em>Daniel Glazman</em></a>&nbsp;</li>
+</ul></li>
+<li><dfn>Tuesday,  1 May 2007</dfn><ul>
+<li><a href="0000.html">HTML Email Workshop - Position Paper</a>&nbsp;<a name="msg0" id="msg0"><em>Jim Kelley</em></a>&nbsp;</li>
+</ul></li>
+</ul>
+<ul>
+<li><dfn><a id="end" name="end">Last message date</a></dfn>: <em>Tuesday, 29 May 2007 06:04:58 UTC</em></li>
+<li><dfn>Archived on</dfn>: Tuesday,  6 January 2015 19:42:17 UTC</li>
+</ul>
+</div>
+<div class="foot">
+<map title="Navigation bar" id="navbarfoot" name="navbarfoot">
+<ul>
+<li><dfn><a href="#first">39 messages</a> sort by</dfn>:
+ [ <a href="thread.html" title="Contemporary discussion threads">thread</a> ]
+ [ <a href="author.html" title="Contemporary messages by author">author</a> ]
+ [ date ]
+ [ <a href="subject.html" title="Contemporary messages by subject">subject</a> ]
+</li>
+<li><dfn>Mail actions</dfn>: [ <a href="mailto:public-html-mail&#x40;&#0119;&#0051;&#0046;&#0111;&#0114;&#0103;">mail a new topic</a> ]</li>
+</ul>
+</map>
+<!-- trailer="footer" -->
+<p><small><em>
+This archive was generated by <a href="http://www.hypermail-project.org/">hypermail 2.3.1</a>
+: Tuesday,  6 January 2015 19:42:17 UTC
+</em></small></p>
+</div>
+</body>
+</html>

--- a/samples/public-index.html
+++ b/samples/public-index.html
@@ -8,9 +8,9 @@
 <title>public-html-mail@w3.org from May 2007: by date</title>
 <meta name="Subject" content="by date" />
 <meta name="robots" content="noindex" />
-<link rel="stylesheet" href="//www.w3.org/StyleSheets/Mail/public-messagelist" type="text/css" />
+<link rel="stylesheet" href="../style/public-messagelist" type="text/css" />
 <link rel="alternate stylesheet" title="Shorter view" 
-    href="//www.w3.org/StyleSheets/Mail/style-short.css" />
+    href="../style/style-short.css" />
 <link rel="help" href="/Help/" />
 <link rel="start" href="../" title= "public-html-mail@w3.org archives" />
 </head>

--- a/samples/public-message.html
+++ b/samples/public-message.html
@@ -9,7 +9,7 @@
 <meta name="Author" content="Chris Newman (Chris.Newman&#x40;&#0083;&#0117;&#0110;&#0046;&#0067;&#0079;&#0077;)" />
 <meta name="Subject" content="Email security position paper" />
 <meta name="Date" content="2007-05-02" />
-<link rel="stylesheet" href="../style/public-message" type="text/css" />
+<link rel="stylesheet" href="../style/public-message.css" type="text/css" />
 <link rel="alternate stylesheet" title="Shorter view" 
     href="../style/style-short.css" />
 <link rel="help" href="/Help/" />

--- a/samples/public-message.html
+++ b/samples/public-message.html
@@ -9,9 +9,9 @@
 <meta name="Author" content="Chris Newman (Chris.Newman&#x40;&#0083;&#0117;&#0110;&#0046;&#0067;&#0079;&#0077;)" />
 <meta name="Subject" content="Email security position paper" />
 <meta name="Date" content="2007-05-02" />
-<link rel="stylesheet" href="//www.w3.org/StyleSheets/Mail/public-message" type="text/css" />
+<link rel="stylesheet" href="../style/public-message" type="text/css" />
 <link rel="alternate stylesheet" title="Shorter view" 
-    href="//www.w3.org/StyleSheets/Mail/style-short.css" />
+    href="../style/style-short.css" />
 <link rel="help" href="/Help/" />
 <link rel="start" href="../" title= "public-html-mail@w3.org archives" />
 </head>

--- a/samples/public-message.html
+++ b/samples/public-message.html
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=us-ascii" />
+<meta name="generator" content="hypermail 2.3.1, see http://www.hypermail-project.org/" />
+<title>Email security position paper from Chris Newman on 2007-05-02 (public-html-mail@w3.org from May 2007)</title>
+<meta name="Author" content="Chris Newman (Chris.Newman&#x40;&#0083;&#0117;&#0110;&#0046;&#0067;&#0079;&#0077;)" />
+<meta name="Subject" content="Email security position paper" />
+<meta name="Date" content="2007-05-02" />
+<link rel="stylesheet" href="//www.w3.org/StyleSheets/Mail/public-message" type="text/css" />
+<link rel="alternate stylesheet" title="Shorter view" 
+    href="//www.w3.org/StyleSheets/Mail/style-short.css" />
+<link rel="help" href="/Help/" />
+<link rel="start" href="../" title= "public-html-mail@w3.org archives" />
+</head>
+<body>
+<div class="head">
+<map title="Navigation bar to upper levels" id="upper">
+<p>
+   <a href="//www.w3.org/" title="W3C home">W3C home</a> &gt;
+   <a href="/" title="Mailing lists archives">Mailing
+    lists</a> &gt;
+   <a href="../../" title="Public mailing
+lists">Public</a> &gt;
+   <a href="../" title="Index of public-html-mail@w3.org" rel="start">public-html-mail@w3.org</a> &gt;
+   <a href="./" rel="contents" title="Messages received in May 2007">May 2007</a>
+</p>
+</map>
+<h1>Email security position paper</h1>
+<!-- received="Wed May 02 16:11:12 2007" -->
+<!-- isoreceived="20070502161112" -->
+<!-- sent="Wed, 02 May 2007 09:11:46 -0700" -->
+<!-- isosent="20070502161146" -->
+<!-- name="Chris Newman" -->
+<!-- email="Chris.Newman&#x40;&#0083;&#0117;&#0110;&#0046;&#0067;&#0079;&#0077;" -->
+<!-- subject="Email security position paper" -->
+<!-- id="3C785A769C70FE58ECC8941F@[192.168.0.103]" -->
+<!-- charset="us-ascii" -->
+<!-- expires="-1" -->
+<map id="navbar" name="navbar">
+<ul class="links">
+<li>
+<dfn>This message</dfn>:
+[ <a href="#start2" name="options1" id="options1" tabindex="1">Message body</a> ]
+ [ <a href="mailto:public-html-mail&#x40;&#0119;&#0051;&#0046;&#0111;&#0114;&#0103;?Subject=Re%3A%20Email%20security%20position%20paper&amp;In-Reply-To=%3C3C785A769C70FE58ECC8941F%40%5B192.168.0.103%5D%3E&amp;References=%3C3C785A769C70FE58ECC8941F%40%5B192.168.0.103%5D%3E" accesskey="r" title="respond to this message">Respond</a> ]
+ [ <a href="#options3">More options</a> ]
+</li>
+<li>
+<dfn>Related messages</dfn>:
+<!-- unext="start" -->
+[ <a href="0003.html" accesskey="d" title="DESCHAMPS Stephane ROSI/SI CLIENT: &quot;RE: Position Paper on Accessibility&quot;">Next message</a> ]
+[ <a href="0001.html" title="Daniel Glazman: &quot;HTML in email Workshop&quot;">Previous message</a> ]
+<!-- unextthread="start" -->
+<!-- ureply="end" -->
+</li>
+</ul>
+</map>
+</div>
+<!-- body="start" -->
+<div class="mail">
+<address class="headers">
+<span id="from">
+<dfn>From</dfn>: Chris Newman &lt;<a href="mailto:Chris.Newman&#x40;&#0083;&#0117;&#0110;&#0046;&#0067;&#0079;&#0077;?Subject=Re%3A%20Email%20security%20position%20paper&amp;In-Reply-To=%3C3C785A769C70FE58ECC8941F%40%5B192.168.0.103%5D%3E&amp;References=%3C3C785A769C70FE58ECC8941F%40%5B192.168.0.103%5D%3E">Chris.Newman&#x40;&#0083;&#0117;&#0110;&#0046;&#0067;&#0079;&#0077;</a>&gt;
+</span><br />
+<span id="date"><dfn>Date</dfn>: Wed, 02 May 2007 09:11:46 -0700</span><br />
+<span id="to"><dfn>To</dfn>: <a href="mailto:public-html-mail&#x40;&#0119;&#0051;&#0046;&#0111;&#0114;&#0103;?Subject=Re%3A%20Email%20security%20position%20paper&amp;In-Reply-To=%3C3C785A769C70FE58ECC8941F%40%5B192.168.0.103%5D%3E&amp;References=%3C3C785A769C70FE58ECC8941F%40%5B192.168.0.103%5D%3E">public-html-mail&#x40;&#0119;&#0051;&#0046;&#0111;&#0114;&#0103;</a>
+</span><br />
+<span id="message-id"><dfn>Message-id</dfn>: &lt;3C785A769C70FE58ECC8941F&#64;[192.168.0.103]&gt;
+</span><br />
+</address>
+<pre id="body">
+<a name="start2" accesskey="j" id="start2"></a>
+I don't have time to attend the meeting, but wanted to make sure you have this 
+input.  This is my personal opinion as a long-time participant in the email 
+industry.
+
+-------
+Email security and client development position paper
+
+Imagine you had a web browser which every day would randomly jump to a web page 
+created by a phishing house (a different one each day) that was trying to break 
+into your computer.  This browser would proceed to execute all javascript, 
+flash, and other active content on that web page?  If you were lucky you would 
+only get a few pieces of new spyware and adware each day, making your computer 
+unusable within a week regardless of the quality of your anti-virus or other 
+protection software.  Then imagine this web browser had unrestricted access to 
+your personal address book and all your business contacts and could trivially 
+use that information to generate emails to those contacts on your behalf?  How 
+would that impact your business relationships?   Would you run this web browser 
+if you had the option to run one that didn't do this?
+
+Next, imagine the second you view one of these phishing web page, the web page 
+owner immediately knows that you actively use your web browser (and when you 
+use it) and can arrange to have your web browser visit their page every day in 
+addition to the other things it does.
+
+That's what rich HTML email would be like and why email vendors work hard to 
+restrict what forms of HTML are permissible (and is one of many reasons why 
+technology-aware users prefer plain text email).  Because email can be sent to 
+an unsolicited recipient, rendering rich email safely is a much greater 
+security and privacy risk for the recipient than a typical web page.  While 
+there was some early research on active content in email that could be used 
+safely (safe-TCL), it was never clear that the benefits would outweigh the 
+risks.
+
+Attempts to &quot;filter&quot; HTML, CSS and javascript to remove known bad things are 
+not viable long term.  There's always another extension by some particular HTML 
+engine that allows risky content embedded in some new part of the language. 
+What's needed is an extensible white-list of HTML and CSS features that is 
+typically safe for use in email.  For an example of such technology, see:
+  &lt;<a href="http://www.feedparser.org/docs/html-sanitization.html">http://www.feedparser.org/docs/html-sanitization.html</a>&gt;
+
+If the W3C were to take the lead on maintaining and standardizing an 
+industry-standard default HTML/CSS whitelist for risky content environments 
+it's likely to (eventually) raise the baseline level of HTML/CSS support in 
+email.  Furthermore, an investigation of why privacy-preserving technology 
+(such as MIME HTML RFC 2557) to embed the complete HTML document and all 
+ancillary data in the email so the client can operate in a &quot;safe no network&quot; 
+privacy mode has failed to deploy well would be interesting.
+
+The current email client market is in a dire state from the viewpoint of 
+innovation.  The vast majority of mail clients generate no revenue for the 
+vendors of those clients and as a result there is extremely limited investment 
+in mail client technology.  Two of the leading innovative cross-platform fat 
+client projects (Mulberry and Eudora) were recently terminated (the former due 
+to chapter 7 bankruptcy, the latter is merging with Thunderbird).  Is there a 
+way that the companies that want more features in email clients could invest 
+money to restart innovation in the mail client industry and possibly make it 
+profitable for independent mail client vendors so there is innovation?  Is 
+other standards work needed to improve the situation?  Can innovation be driven 
+by clients on portable devices and then move back to the more traditional 
+client environments?  What sort of rich client features would benefit mail 
+users so much that it would start a mass migration?
+-------
+
+                - Chris
+</pre>
+<span id="received"><dfn>Received on</dfn> Wednesday,  2 May 2007 16:11:12 UTC</span>
+</div>
+<!-- body="end" -->
+<div class="foot">
+<map id="navbarfoot" name="navbarfoot" title="Related messages">
+<ul class="links">
+<li><dfn>This message</dfn>: [ <a href="#start2">Message body</a> ]</li>
+<!-- lnext="start" -->
+<li><dfn>Next message</dfn>: <a href="0003.html" title="Next message in the list">DESCHAMPS Stephane ROSI/SI CLIENT: "RE: Position Paper on Accessibility"</a></li>
+<li><dfn>Previous message</dfn>: <a href="0001.html" title="Previous message in the list">Daniel Glazman: "HTML in email Workshop"</a></li>
+<!-- lnextthread="start" -->
+<!-- lreply="end" -->
+</ul>
+<ul class="links">
+<li><a name="options3" id="options3"></a><dfn>Mail actions</dfn>: [ <a href="mailto:public-html-mail&#x40;&#0119;&#0051;&#0046;&#0111;&#0114;&#0103;?Subject=Re%3A%20Email%20security%20position%20paper&amp;In-Reply-To=%3C3C785A769C70FE58ECC8941F%40%5B192.168.0.103%5D%3E&amp;References=%3C3C785A769C70FE58ECC8941F%40%5B192.168.0.103%5D%3E">respond to this message</a> ] [ <a href="mailto:public-html-mail&#x40;&#0119;&#0051;&#0046;&#0111;&#0114;&#0103;">mail a new topic</a> ]</li>
+<li><dfn>Contemporary messages sorted</dfn>: [ <a href="index.html#msg2" title="Contemporary messages by date">by date</a> ] [ <a href="thread.html#msg2" title="Contemporary discussion threads">by thread</a> ] [ <a href="subject.html#msg2" title="Contemporary messages by subject">by subject</a> ] [ <a href="author.html#msg2" title="Contemporary messages by author">by author</a> ]</li>
+<li><dfn>Help</dfn>: [ <a href=
+   "/Help/" accesskey="h" rel="help">How to use the archives</a> ] [ <a href=
+   "https://www.w3.org/Search/Mail/Public/search?type-index=public-html-mail&amp;index-type=t">Search in the archives</a> ]
+</li></ul>
+</map>
+</div>
+<!-- trailer="footer" -->
+<p><small><em>
+This archive was generated by <a href="http://www.hypermail-project.org/">hypermail 2.3.1</a>
+: Tuesday,  6 January 2015 19:42:17 UTC
+</em></small></p>
+</body>
+</html>

--- a/style/base.css
+++ b/style/base.css
@@ -1,0 +1,69 @@
+/* Copyright 1997-2003 W3C (MIT, ERCIM, Keio). All Rights Reserved.
+   The following software licensing rules apply:
+   http://www.w3.org/Consortium/Legal/copyright-software */
+
+/* $Id: base.css,v 1.14 2014-02-24 23:11:24 sysbot Exp $ */
+
+/* this style sheet defines the basic style for all W3C pages */
+/* you can point to this by adding:
+
+     <LINK rel="Stylesheet" href="/StyleSheets/base">
+
+
+   in the HEAD of your HTML document */
+
+body {
+  font-family: sans-serif;
+  color: black;
+  background: white;
+}
+
+a:link, a:active {
+  color: #00e;
+  background: transparent;
+}
+
+a:visited {
+  color: #529;
+  background: transparent;
+}
+
+div.intro {
+  margin-left: 5%;
+  margin-right: 5%;
+  font-style: italic
+}
+
+pre {
+  font-family: monospace
+}
+
+a:link img, a:visited img {
+   border-style: none
+}
+
+a img { color: white; }        /* hide the border in Netscape 4 */
+@media all {                   /* hide from Netscape 4 */
+  a img { color: inherit; }    /* undo the rule above */
+}
+
+ul.toc, ol.toc {
+  list-style: disc;
+  list-style: none;
+}
+
+div.issue {
+  padding: 0.5em;
+  border: none;
+  margin-right: 5%;
+}
+
+.hideme { display: none }
+
+@media print {
+
+  table {
+    page-break-inside: avoid
+  }
+
+}

--- a/style/public-message.css
+++ b/style/public-message.css
@@ -6,8 +6,8 @@
 
 /* W3C Message Archive - public message */
 
-@import url(/StyleSheets/base.css);
-@import url(/StyleSheets/Mail/message.css);
+@import url(base.css);
+@import url(message.css);
 
 /* Leave message itself white but rest
 ** of metadata very pale grey

--- a/style/public-messagelist.css
+++ b/style/public-messagelist.css
@@ -6,7 +6,7 @@
 
 /* @@ */
 
-@import url(/StyleSheets/base.css);
+@import url(base.css);
 
 
 


### PR DESCRIPTION
The idea of this PR is to use GH Pages to serve a few samples of {public, member-only, team-only} real examples of {indices, messages} taken from our MLs. That way, we can work on the new CSS (and new JS) and share the results with anyone.

To achieve this, I recommend we:
1. Merge this PR.
2. Replace branch `master` with `gh-pages` and make it the default branch ([here](https://w3c.github.io/specs.html) is an explanation of how to do that, although that one's overtly complex as it also mentions spec-generators etc). Once that is done, we'll have the samples available at [`w3c.github.io/mailing-list-archives/samples`](https://w3c.github.io/mailing-list-archives/samples).
3. Link to that URL from the tagline of the project (click &ldquo;Edit&rdquo; in &ldquo;Modernizing W3C's mailing list archives — Edit&rdquo;) so that it's at hand for everyone visiting the page of the project.

I haven't included member- nor team-only samples yet because those require removing all sensitive information (e-mail addresses, the body of messages themselves) and replacing them with _lorem ipsum_. But I will soon.
