### PR TITLE
[WIP] Enhance presentation of messages

### DIFF
--- a/js/message-proposal-1.js
+++ b/js/message-proposal-1.js
@@ -1,0 +1,38 @@
+'use strict';
+
+$(document).ready(function() {
+
+    const URL = /(\s)(https?:\/\/[^\s]+)(\s)/gi;
+    var md = window.markdownit();
+    var container = $('#body');
+    var link = $('#overlay > a');
+    var original = container.text();
+    var enhanced;
+    var formatted = false;
+
+    var processOriginal = function() {
+	return original.replace(URL, function(foo, p1, p2, p3) {
+	    return p1 + '[`' + p2 + '`](' + p2 + ')' + p3;
+	});
+    };
+
+    var toggleFormatting = function() {
+
+	if (formatted) {
+            container.text(original);
+	    container.removeClass('rich').addClass('plain');
+	    link.text('Format');
+	} else {
+            container.html(md.render(enhanced));
+	    container.removeClass('plain').addClass('rich');
+	    link.text('Plain');
+	}
+
+	formatted = !formatted;
+    };
+
+    link.click(toggleFormatting);
+    enhanced = processOriginal(original);
+    toggleFormatting();
+
+});

--- a/samples/message-proposal-1.html
+++ b/samples/message-proposal-1.html
@@ -13,7 +13,7 @@
 <meta name="Subject" content="Streams after receiving GOAWAY" />
 <meta name="Date" content="2015-11-15" />
 
-<link href="https://www.w3.org/scripts/bootstrap/3.3/css/bootstrap.css"
+<link href="//www.w3.org/scripts/bootstrap/3.3/css/bootstrap.min.css"
 rel="stylesheet">
 
 <link href="../style/message-proposal-1.css" rel="stylesheet">
@@ -27,12 +27,12 @@ rel="stylesheet">
 
 <body>
 
-<nav class="navbar navbar-default navbar-static-top">
+<nav id="gutter-top" class="navbar navbar-default navbar-static-top">
 
 <div class="container-fluid">
 
 <ul class="nav navbar-nav nav-pills">
-  <li><a href="http://www.w3.org/">W3C</a></li>
+  <li><a href="http://www.w3.org/"><img src="//www.w3.org/scripts/logo-w3c-mobile-lg.png" alt="W3C logo" /></a></li>
   <li><a href="https://lists.w3.org/"
       class="hidden-xs">Lists</a></li>
   <li><a href="https://lists.w3.org/Archives/Public/"
@@ -55,7 +55,7 @@ rel="stylesheet">
 
 </nav>
 
-<div class="container-fluid message">
+<div id="main" class="container-fluid message">
 <div class="row">
 
 <div class="col-md-8">

--- a/samples/message-proposal-1.html
+++ b/samples/message-proposal-1.html
@@ -81,29 +81,46 @@ rel="stylesheet">
 <span id="to"><dfn>To:</dfn> HTTP Working Group &lt;<a href="mailto:ietf-http-wg&#x40;&#0119;&#0051;&#0046;&#0111;&#0114;&#0103;?Subject=Re%3A%20Streams%20after%20receiving%20GOAWAY&amp;In-Reply-To=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E&amp;References=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E">ietf-http-wg&#x40;&#0119;&#0051;&#0046;&#0111;&#0114;&#0103;</a>&gt;
 </span><br />
 </div><!--/.headers-->
-<div id="body"><a accesskey="j" id="start173"></a>I'm about to deliberately violate the letter of a MUST NOT because I
+
+<div id="body-wrapper">
+<div id="body" class="plain"><a accesskey="j" id="start173"></a>I'm about to deliberately violate the letter of a MUST NOT because I
 believe it's overly strict.
 
-&quot;Receivers of a GOAWAY frame MUST NOT open additional streams on the
-connection...&quot;
+> &quot;Receivers of a GOAWAY frame MUST NOT open additional streams on the connection...&quot;
 
 When my server wants to close a connection it sends a GOAWAY with last
-stream id set to a value somewhat higher than anything it has received. It
+stream id set to a value _somewhat higher than anything it has received_. It
 then keeps the connection until the reported last id is reached or enough
-time goes by.
+time goes by [1]. For reference: http://example.com/foo
 
-When the client gets a GOAWAY it will immediately start establishing a new
-connection, continue issuing new requests up to the reported last id, and
+    $ ls
+    a.txt foo.md higher-number.docx
+    $ rm foo.md
+
+Also:
+```javascript
+container.removeClass('rich').addClass('plain');
+```
+
+When the client gets a GOAWAY **it will immediately start establishing a new
+connection**, continue issuing new requests up to the reported last id, and
 close the old connection when it either has a new connection or has used
-all the reported streams.
+all the reported streams[1][2].
 
-The goal is to avoid suspending requests in a high volume server to server
-environment while waiting for new connections. I don't see how it conflicts
-with any conforming implementation, am I missing something?
+The goal is:
+* to avoid suspending requests in a high volume server to server environment
+* while waiting for new connections.
+
+I don't see how it conflicts with any conforming implementation, am I missing something?
 
 Thanks,
 Glen
+
+[1] https://w3.org/foo/bar.html
+[2] http://WWW.archive.org/
 </div><!--/#body-->
+<div id="overlay"><a href="#">Remove formatting</a></div>
+</div><!--/#body-wrapper-->
 
 <p>
 <span id="received"><dfn>Received on:</dfn> Sunday, 15 November 2015 10:24:44 UTC</span><br />
@@ -226,6 +243,9 @@ bootstrap, with a thread pane and search box added.
 
 </div><!-- /.container -->
 
+<script type="text/javascript" src="//www.w3.org/scripts/jquery/2.1/jquery.min.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/markdown-it/5.0.2/markdown-it.min.js"></script>
+<script type="text/javascript" src="../js/message-proposal-1.js"></script>
 </body>
 
 </html>

--- a/samples/message-proposal-1.html
+++ b/samples/message-proposal-1.html
@@ -75,10 +75,10 @@ rel="stylesheet">
 <div class="message">
 <div class="headers">
 <span id="from">
-<dfn>From</dfn>: Glen Knowles &lt;<a href="mailto:gknowles&#x40;&#0105;&#0101;&#0101;&#0101;&#0046;&#0111;&#0114;&#0103;?Subject=Re%3A%20Streams%20after%20receiving%20GOAWAY&amp;In-Reply-To=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E&amp;References=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E">gknowles&#x40;&#0105;&#0101;&#0101;&#0101;&#0046;&#0111;&#0114;&#0103;</a>&gt;
+<dfn>From:</dfn> Glen Knowles &lt;<a href="mailto:gknowles&#x40;&#0105;&#0101;&#0101;&#0101;&#0046;&#0111;&#0114;&#0103;?Subject=Re%3A%20Streams%20after%20receiving%20GOAWAY&amp;In-Reply-To=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E&amp;References=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E">gknowles&#x40;&#0105;&#0101;&#0101;&#0101;&#0046;&#0111;&#0114;&#0103;</a>&gt;
 </span><br />
-<span id="date"><dfn>Date</dfn>: Sun, 15 Nov 2015 02:24:15 -0800</span><br />
-<span id="to"><dfn>To</dfn>: HTTP Working Group &lt;<a href="mailto:ietf-http-wg&#x40;&#0119;&#0051;&#0046;&#0111;&#0114;&#0103;?Subject=Re%3A%20Streams%20after%20receiving%20GOAWAY&amp;In-Reply-To=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E&amp;References=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E">ietf-http-wg&#x40;&#0119;&#0051;&#0046;&#0111;&#0114;&#0103;</a>&gt;
+<span id="date"><dfn>Date:</dfn> Sun, 15 Nov 2015 02:24:15 -0800</span><br />
+<span id="to"><dfn>To:</dfn> HTTP Working Group &lt;<a href="mailto:ietf-http-wg&#x40;&#0119;&#0051;&#0046;&#0111;&#0114;&#0103;?Subject=Re%3A%20Streams%20after%20receiving%20GOAWAY&amp;In-Reply-To=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E&amp;References=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E">ietf-http-wg&#x40;&#0119;&#0051;&#0046;&#0111;&#0114;&#0103;</a>&gt;
 </span><br />
 </div><!--/.headers-->
 <div id="body"><a accesskey="j" id="start173"></a>I'm about to deliberately violate the letter of a MUST NOT because I
@@ -106,8 +106,8 @@ Glen
 </div><!--/#body-->
 
 <p>
-<span id="received"><dfn>Received on</dfn> Sunday, 15 November 2015 10:24:44 UTC</span><br />
-<span id="message-id"><dfn>Message-ID</dfn>: &lt;CAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg&#64;mail.gmail.com&gt;</span>
+<span id="received"><dfn>Received on:</dfn> Sunday, 15 November 2015 10:24:44 UTC</span><br />
+<span id="message-id"><dfn>Message-ID:</dfn> &lt;CAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg&#64;mail.gmail.com&gt;</span>
 </p>
 
 </div><!--/.message-->

--- a/style/message-proposal-1.css
+++ b/style/message-proposal-1.css
@@ -49,6 +49,17 @@ div#main {
   margin-top:            73px;
 }
 
+div#overlay {
+  position:              absolute;
+  top:                   0;
+  right:                 0;
+  min-width:             5em;
+  padding:               0.1em 0.5em;
+  border-color:          #eee;
+  border-style:          solid;
+  border-width:          0 0 2px 2px;
+}
+
 a:link, a:active {
   color: #00e;
   background: transparent;
@@ -139,9 +150,23 @@ p.spamfooter{
  font-size: small;
 }
 
-div#body {
+div#body-wrapper {
+    position: relative;
     display: block;
     unicode-bidi: embed;
+    background: white;
+    padding: 0.5em;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+}
+
+div#body-wrapper a {
+    margin: 0;
+    padding: 0;
+    display: inline;
+}
+
+div#body.plain {
     font-family: monospace;
     white-space: pre;
     white-space: pre-wrap;       /* css-3 */
@@ -149,16 +174,14 @@ div#body {
     white-space: -pre-wrap;      /* Opera 4-6 */
     white-space: -o-pre-wrap;    /* Opera 7 */
     word-wrap: break-word;       /* Internet Explorer 5.5+ */
-    background: white;
-    padding: 0.5em;
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
 }
 
-div#body a {
-    margin: 0;
-    padding: 0;
-    display: inline;
+div#body {
+    padding-top: 1em;
+}
+
+div#body.rich {
+    font-size: larger;
 }
 
 div.message {

--- a/style/message-proposal-1.css
+++ b/style/message-proposal-1.css
@@ -93,7 +93,12 @@ div.issue {
 ** but can't
 */
 
-dfn {font-weight: bold;}
+dfn {
+  display:     inline-block;
+  min-width:   8em;
+  font-weight: bold;
+}
+
 .mail, .head { border-bottom:1px solid black;}
 map ul {list-style:none;}
 #message-id { font-size: small;}

--- a/style/message-proposal-1.css
+++ b/style/message-proposal-1.css
@@ -16,6 +16,39 @@ body {
   line-height: 1.2em;
 }
 
+nav#gutter-top {
+  position:              fixed;
+  top:                   0;
+  left:                  0;
+  right:                 0;
+  height:                53px;
+  background-color:      #2975ac;
+  border:                none;
+  font-size:             larger;
+  color:                 #e0e0e0;
+}
+
+nav#gutter-top > .container-fluid {
+  padding-left:          0;
+}
+
+.navbar-default .navbar-nav > li > a {
+  color:                 #e0e0e0;
+}
+.navbar-default .navbar-nav > li > a:focus,
+.navbar-default .navbar-nav > li > a:hover,
+.navbar-default .navbar-nav > li > a:active {
+  color:                 #ffffff;
+}
+
+.navbar-default .navbar-nav li:first-child a {
+  padding:               0;
+}
+
+div#main {
+  margin-top:            73px;
+}
+
 a:link, a:active {
   color: #00e;
   background: transparent;


### PR DESCRIPTION
Quite a few changes together (sorry, they were inter-related, and some of them popped up to my mind as I was busy with others; we can split in several PRs for easier review).

In order or importance:
## 

Trying to format common syntax in plain-text messages. Achieved with a combination of [markdown-it](https://markdown-it.github.io/) + custom text replacement. The sample message has been extended to showcase these replacements. This is a _progressive enhancement_ (without JS, the message looks as it used to).
- `*emphasis*`, `**more emphasis**`, `_underline_`, etc.
- `foo[1]` in text + `[1] http://foo` in footer, when giving URLs as references.
- _Things that look like URLs in text_ (add hyperlinks and display in monospace).
- `> foo` for quotes.
- Lists using `*` as a bullet.
- etc.

Formatting is done by default, and the user can toggle. We could make it disabled by default to avoid breaking the display of messages that aren't intended to be read as natural language (eg, someone sends by e-mail a chunk of source code). What I would prefer is to try and infer from the message itself whether formatting makes sense; having a simple heuristic that would decide that.

[TO-DO] I'd still like to replace footnotes (`[1]`) with the respective URL in the footer.
## 

Message headers now aligned vertically (requires a tiny change in HTML: moving the colons _inside_ `<dfn>`).
## 

Applied the new blue header that we have on other recent pages (labs, /scripts). Also, it's fixed at the top, so scrolling doesn't hide it.
## 

Use minified Bootstrap; add jQuery and markdown-it.
