### PR TITLE
Message headers: better aligned, collapsible

### DIFF
--- a/js/base.js
+++ b/js/base.js
@@ -41,7 +41,17 @@ const init = function($, markdownit) {
             ENHANCED = MDIT.render(processOriginal(ORIGINAL)),
             MESSAGE_CONTAINER = $('div#message-container'),
             THREAD_CONTAINER = $('div#thread-container'),
-            AUTHOR = $('meta[name="Author"]');
+            AUTHOR = $('meta[name="Author"]'),
+            ROW_DETAILED = $('.headers .detailed'),
+            ROW_GUTTER = $('#gutter'),
+            GUTTER = $('a', ROW_GUTTER),
+            GUTTER_GLYPH = $('#glyph'),
+            TR_UP_FULL = '&#9650;',
+            TR_UP_EMPTY = '&#9651;',
+            TR_DOWN_FULL = '&#9660;',
+            TR_DOWN_EMPTY = '&#9661;';
+
+        var detailsVisible = true;
 
         const toggleThread = function(event) {
             const OPTION = event.target.value;
@@ -66,6 +76,35 @@ const init = function($, markdownit) {
             }
         };
 
+        const highlightGutter = function(event) {
+            if (event && 'mouseenter' === event.type) {
+                if (detailsVisible) {
+                    GUTTER_GLYPH.html(TR_UP_FULL);
+                } else {
+                    GUTTER_GLYPH.html(TR_DOWN_FULL);
+                }
+            } else {
+                // ie, 'mouseleave' === event.type
+                if (detailsVisible) {
+                    GUTTER_GLYPH.html(TR_UP_EMPTY);
+                } else {
+                    GUTTER_GLYPH.html(TR_DOWN_EMPTY);
+                }
+            }
+        };
+
+        const toggleDetails = function() {
+            detailsVisible = !detailsVisible;
+            if (detailsVisible) {
+                ROW_DETAILED.removeClass('hidden');
+                GUTTER_GLYPH.html(TR_UP_EMPTY);
+            } else {
+                ROW_DETAILED.addClass('hidden');
+                GUTTER_GLYPH.html(TR_DOWN_EMPTY);
+            }
+            return false;
+        };
+
         if (AUTHOR && AUTHOR.attr('Content')) {
             const PATTERN_EMAIL = /\b[a-z0-9\._%+\-]+@[a-z0-9\.\-]+\.[a-z]{2,}\b/i, // regex from http://www.regular-expressions.info/email.html
                 ADDRESS = PATTERN_EMAIL.exec(AUTHOR.attr('Content'));
@@ -82,6 +121,10 @@ const init = function($, markdownit) {
         if (OPT_MD.length) toggleFormatting();
         OPT_MD.change(toggleFormatting);
         OPTS_THREAD.change(toggleThread);
+        GUTTER.hover(highlightGutter);
+        GUTTER.click(toggleDetails);
+        ROW_GUTTER.removeClass('hidden');
+        toggleDetails();
         OPTIONS.addClass('active');
 
     });

--- a/samples/index.html
+++ b/samples/index.html
@@ -32,6 +32,8 @@
           from <a href="https://github.com/tripu">@tripu</a></li>
         <li><a href="message-proposal-gravatars.html">Message proposal: with gravatars</a>
           from <a href="https://github.com/tripu">@tripu</a></li>
+        <li><a href="message-proposal-fields.html">Message proposal: better mail headers (fields)</a>
+          from <a href="https://github.com/tripu">@tripu</a></li>
       </ul>
     </main>
 

--- a/samples/message-proposal-fields.html
+++ b/samples/message-proposal-fields.html
@@ -1,0 +1,263 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+<title>Streams after receiving GOAWAY from Glen Knowles on 2015-11-15 (ietf-http-wg@w3.org from October to December 2015)</title>
+
+<meta name="Author" content="Glen Knowles (gknowles&#x40;&#0105;&#0101;&#0101;&#0101;&#0046;&#0111;&#0114;&#0103;)" />
+<meta name="Subject" content="Streams after receiving GOAWAY" />
+<meta name="Date" content="2015-11-15" />
+
+<link href="https://www.w3.org/scripts/bootstrap/3.3/css/bootstrap.css"
+rel="stylesheet">
+
+<link href="../style/message-proposal-1.css" rel="stylesheet">
+<link href="../style/thread.css" rel="stylesheet">
+
+<link rel="help" href="/Help/" />
+<link rel="start" href="../" title= "ietf-http-wg@w3.org archives" />
+
+</head>
+
+<body>
+
+<nav class="navbar navbar-default navbar-static-top">
+
+<div class="container-fluid">
+
+<ul class="nav navbar-nav nav-pills">
+  <li><a href="http://www.w3.org/">W3C</a></li>
+  <li><a href="https://lists.w3.org/"
+      class="hidden-xs">Lists</a></li>
+  <li><a href="https://lists.w3.org/Archives/Public/"
+      class="hidden-xs">Public</a></li>
+  <li><a href="https://lists.w3.org/Archives/Public/ietf-http-wg/">ietf-http-wg</a></li>
+  <li><a href="https://lists.w3.org/Archives/Public/ietf-http-wg/2015OctDec/"
+      class="hidden-xs">October to December 2015</a></li>
+</ul>
+
+<form class="navbar-form navbar-right hidden-xs">
+<div class="form-group">
+  <input type="text" class="form-control" size="40"
+  placeholder="Search this archive">
+</div>
+<button type="submit" class="btn btn-default">Search</button>
+</form>
+
+
+</div><!-- /.container-fluid -->
+
+</nav>
+
+<div class="container-fluid message">
+<div class="row">
+
+<div class="col-md-8">
+
+<h1>Streams after receiving GOAWAY</h1>
+<!-- received="Sun Nov 15 10:24:44 2015" -->
+<!-- isoreceived="20151115102444" -->
+<!-- sent="Sun, 15 Nov 2015 02:24:15 -0800" -->
+<!-- isosent="20151115102415" -->
+<!-- name="Glen Knowles" -->
+<!-- email="gknowles&#x40;&#0105;&#0101;&#0101;&#0101;&#0046;&#0111;&#0114;&#0103;" -->
+<!-- subject="Streams after receiving GOAWAY" -->
+<!-- id="CAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg@mail.gmail.com" -->
+<!-- charset="UTF-8" -->
+<!-- expires="-1" -->
+<!-- body="start" -->
+<div class="message">
+<div class="headers">
+    <div class="row">
+        <div class="key col-md-2">From:</div>
+        <div class="value col-md-10">
+            <a href="mailto:gknowles@ieee.org?Subject=Re%3A%20Streams%20after%20receiving%20GOAWAY&In-Reply-To=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E&References=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E">
+                <span class="name">Glen Knowles</span>
+                <code>&lt;gknowles@ieee.org&gt;</code>
+            </a>
+        </div>
+    </div>
+    <div class="row">
+        <div class="key col-md-2">Date:</div>
+        <div class="value col-md-10">
+            <span class="name">Sun, 15 Nov 2015 02:24:15 -0800</span>
+        </div>
+    </div>
+    <div class="row">
+        <div class="key col-md-2">To:</div>
+        <div class="value col-md-10">
+            <a href="mailto:ietf-http-wg@w3.org?Subject=Re%3A%20Streams%20after%20receiving%20GOAWAY&In-Reply-To=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E&References=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E">
+                <span class="name">HTTP Working Group</span>
+                <code>&lt;ietf-http-wg@w3.org&gt;</code>
+            </a>
+        </div>
+    </div>
+    <div class="row detailed">
+        <div class="key col-md-2">Received:</div>
+        <div class="value col-md-10">
+            <span class="name">Sunday, 15 November 2015 10:24:44 UTC</span>
+        </div>
+    </div>
+    <div class="row detailed">
+        <div class="key col-md-2">Message&nbsp;ID:</div>
+        <div class="value col-md-10">
+            <span class="name"><code>&lt;CAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg&#64;mail.gmail.com&gt;</code></span>
+        </div>
+    </div>
+    <div id="gutter" class="row hidden">
+        <a href="#">
+            <!-- <div class="col-md-1"></div> -->
+            <div id="glyph" class="col-md-10 col-md-offset-1">&#9661;</div>
+            <!-- <div class="col-md-1"></div> -->
+        </a>
+    </div>
+</div><!--/.headers-->
+<div id="body"><a accesskey="j" id="start173"></a>I'm about to deliberately violate the letter of a MUST NOT because I
+believe it's overly strict.
+
+&quot;Receivers of a GOAWAY frame MUST NOT open additional streams on the
+connection...&quot;
+
+When my server wants to close a connection it sends a GOAWAY with last
+stream id set to a value somewhat higher than anything it has received. It
+then keeps the connection until the reported last id is reached or enough
+time goes by.
+
+When the client gets a GOAWAY it will immediately start establishing a new
+connection, continue issuing new requests up to the reported last id, and
+close the old connection when it either has a new connection or has used
+all the reported streams.
+
+The goal is to avoid suspending requests in a high volume server to server
+environment while waiting for new connections. I don't see how it conflicts
+with any conforming implementation, am I missing something?
+
+Thanks,
+Glen
+</div><!--/#body-->
+
+</div><!--/.message-->
+<!-- body="end" -->
+
+<p>Contemporary messages sorted by:
+  <a href="index.html#msg173">date</a>,
+  <a href="thread.html#msg173">thread</a>,
+  <a href="subject.html#msg173">subject</a>,
+  <a href="author.html#msg173">author</a>
+</p>
+
+<p></p>
+
+<p>
+This archive was generated by
+<a href="http://www.hypermail-project.org/">hypermail 2.3.1</a>:
+Sunday, 15 November 2015 10:24:47 UTC
+</p>
+
+<p><a href="https://lists.w3.org/Help/" accesskey="h"
+rel="help">How to use these archives</a></p>
+
+
+</div><!-- /.col-md-8 -->
+
+<div class="col-md-4">
+
+<div class="actions btn-group btn-group-justified">
+
+<a class="btn btn-default" href="0174.html" title="Next message in this thread">Next message</a>
+
+<a class="btn btn-default"
+href="mailto:ietf-http-wg&#x40;&#0119;&#0051;&#0046;&#0111;&#0114;&#0103;?Subject=Re%3A%20Streams%20after%20receiving%20GOAWAY&amp;In-Reply-To=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E&amp;References=%3CCAJCH0yBs5LxvYmgvbLHX7NgSptfBUF4TB7tw_OeuyFpTiiLbUg%40mail.gmail.com%3E"
+accesskey="r" title="Reply to this message">Reply</a>
+
+<a class="btn btn-default" href="mailto:ietf-http-wg&#x40;&#0119;&#0051;&#0046;&#0111;&#0114;&#0103;" title="Start a new topic">New topic</a>
+
+</div><!-- /.actions -->
+
+<p>&nbsp;</p>
+
+<p><a class="btn btn-default pull-right" href="http://www.w3.org/Mail/flatten/index?subject=https%3A%2F%2Flists.w3.org%2FArchives%2FPublic%2Fietf-http-wg%2F2015OctDec%2F0173.html&amp;list=">Flatten</a></p>
+
+<p>This thread:</p>
+
+<div class="thread">
+<ul>
+  <li><a href="#" class="current">Glen Knowles (Nov 15)</a>
+  <ul>
+   <li><a href="#">Cory Benfield (Nov 15)</a>
+   <ul>
+    <li><a href="#">Glen Knowles (Nov 15)</a>
+    <ul>
+     <li><a href="#">Cory Benfield (Nov 15)</a>
+     <ul>
+      <li><a href="#">Glen Knowles (Nov 15)</a>
+      <ul>
+       <li><a href="#">Matthew Kerwin (Nov 16)</a></li>
+       <li><a href="#">Eitan Adler (Nov 15)</a></li>
+       <li><a href="#">Willy Tarreau (Nov 16)</a></li>
+       <li><a href="#">Amos Jeffries (Nov 16)</a>
+	<ul>
+	<li><a href="#">Stefan Eissing (Nov 16)</a></li>
+	</ul>
+       </li>
+      </ul>
+     </li>
+     </ul>
+    </li>
+    </ul>
+    </li>
+   </ul>
+   </li>
+  <li><a href="#">Patrick McManus (Nov 15)</a>
+  <ul>
+    <li><a href="#">Mike Bishop (Nov 16)</a></li>
+   </ul>
+  </li>
+  </ul>
+  </li>
+ </ul>
+</div>
+
+</div><!-- /.col-md-4 -->
+
+</div><!-- /.row -->
+
+</div><!-- /.container -->
+
+<div class="container-fluid">
+</div><!-- /.container-fluid -->
+
+<hr>
+
+<div class="container alert alert-warning">
+
+<p>This page is an early draft of what an updated message page might look
+like in a <a href="https://github.com/w3c/mailing-list-archives">restyling
+of W3C's mailing list archives</a>.</p>
+
+<p>See <a
+href="https://lists.w3.org/Archives/Public/ietf-http-wg/2015OctDec/0173.html">the
+original message in our archives</a> for comparison.</p>
+
+<p>This is not a complete proposal, only a quick conversion to HTML5 and
+bootstrap, with a thread pane and search box added.
+<p>
+
+<p>Switch background colors:
+<a href="#" onMouseOver="body.style.background='#eee'">public</a>,
+<a href="#" onMouseOver="body.style.background='#e2edfe'">member</a>,
+<a href="#" onMouseOver="body.style.background='#fff6e0'">team</a>.
+(requires js)
+</p>
+
+</div><!-- /.container -->
+
+<script data-main="../js/base" src="https://www.w3.org/scripts/requirejs/2.1/require.min"></script>
+</body>
+
+</html>

--- a/style/message-proposal-1.css
+++ b/style/message-proposal-1.css
@@ -60,7 +60,6 @@ div.issue {
 ** but can't
 */
 
-dfn {font-weight: bold;}
 .mail, .head { border-bottom:1px solid black;}
 map ul {list-style:none;}
 #message-id { font-size: small;}
@@ -123,6 +122,9 @@ div.message {
 h1 {
     margin-top: 0;
     font-size: 150%;
+    text-shadow: .05em 0 .05em #808080;
+    font-style: italic;
+    font-family: serif;
 }
 
 a:hover {
@@ -264,4 +266,41 @@ div#body blockquote {
 
 #gravatar.active {
   visibility: visible;
+}
+
+/**
+ * Styles to improve the message headers
+ */
+
+.headers .key {
+  font-weight: bold;
+}
+
+.headers .value {
+  color: #606060;
+}
+
+.headers .name {
+  color: #000000;
+}
+
+.headers code {
+  font-size: 1em;
+  padding-left: 0;
+  background-color: transparent;
+  color: #606060;
+}
+
+#gutter {
+  text-align: center;
+  text-decoration: none;
+  color: #000000;
+}
+
+#gutter a:hover #glyph {
+  background-color: #f8f8f8;
+}
+
+.headers .hidden {
+  visibility: hidden;
 }


### PR DESCRIPTION
For readability, align message headers vertically. Use font weight and colour to separate field names from values, and to highlight the name of the sender/list as opposed to their address (webmail software does this, and I find it more elegant).

Also, hide by default headers that are less useful. The user can click on a link to toggle these other headers.

This requires JS, but only to show/hide the &ldquo;extended&rdquo; headers. We could simply align them better, as I'm suggesting, and not hide any of them (right now, if there's no JS, the user gets only the better alignment and formatting).

(It's one of three improvements recycled from #5.)
